### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 The **Multi-Cluster MCP Server** provides a robust gateway for Generative AI (GenAI) systems to interact with multiple Kubernetes clusters through the Model Context Protocol (MCP). It facilitates comprehensive operations on Kubernetes resources, streamlined multi-cluster management, and delivered interactive cluster observability.
 
+<a href="https://glama.ai/mcp/servers/@yanmxa/multicluster-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yanmxa/multicluster-mcp-server/badge" alt="Multi-Cluster Server MCP server" />
+</a>
+
 ## **🚀 Features**
 
 ### 🛠️ MCP Tools - Kubernetes Cluster Awareness


### PR DESCRIPTION
This PR adds a badge for the [Multi-Cluster MCP Server](https://glama.ai/mcp/servers/@yanmxa/multicluster-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yanmxa/multicluster-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yanmxa/multicluster-mcp-server/badge" alt="Multi-Cluster Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

## Summary by Sourcery

Documentation:
- Embed the Multi-Cluster MCP Server badge linking to its Glama directory listing in the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a visual badge linking to the Multi-Cluster MCP Server page on glama.ai in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->